### PR TITLE
center logo for mobile

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -27,6 +27,9 @@
   right: 0;
   box-shadow: 0px 5px 5px lightgrey;
   z-index: 100;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .header__title {


### PR DESCRIPTION
- logo was not centered on mobile, tried "align-items: center"

![image](https://user-images.githubusercontent.com/57504815/75150998-f419b580-5705-11ea-890e-cdb433745f20.png)


- in the inspector, the logo is always displayed in the center... 🤷

![image](https://user-images.githubusercontent.com/57504815/75151030-0136a480-5706-11ea-9f42-377ea3f77704.png)

![image](https://user-images.githubusercontent.com/57504815/75151054-11e71a80-5706-11ea-871a-75f97e953735.png)

![image](https://user-images.githubusercontent.com/57504815/75151129-3642f700-5706-11ea-8a1f-8f6b7d029e55.png)
